### PR TITLE
Add Support for Instruction Aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if (NOT (CMAKE_CROSSCOMPILING AND WIN32))
             test/test_instructions/test_control_instructions.cpp
             test/test_instructions/test_memory_instructions.cpp
             test/test_instructions/test_pseudo_instructions.cpp
+            test/test_instructions/test_aliased_instructions.cpp
             test/test_utils.cpp
             test/test_instructions/test_cp0_instructions.cpp
             test/test_instructions/test_cp1_instructions.cpp

--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -69,31 +69,44 @@ public:
  * Execution to indicate that the program has terminated successfully with the given code
  */
 class ExecExit : public std::runtime_error {
-    int errorCode;
+    int32_t errorCode;
+
+    /**
+     * Constructs a message for the execution exit exception
+     * @param message The original error message to display
+     * @param code The exit code of the program
+     * @return The formatted message
+     */
+    static std::string constructMessage(const std::string& message, const int32_t code) {
+        return std::format("{} (code {})", message, code);
+    }
 
 public:
-    explicit ExecExit(const std::string& message, const int code) :
-        std::runtime_error(message), errorCode(code) {}
+    explicit ExecExit(const std::string& message, const int32_t code) :
+        std::runtime_error(constructMessage(message, code)), errorCode(code) {}
 
     /**
      * Get the error code of the exception
      * @return The error code
      */
-    [[nodiscard]] int code() const { return errorCode; }
+    [[nodiscard]] int32_t code() const { return errorCode; }
 };
 
 
 /**
- * Execution exit to indicate that the debugging program has terminated due to a debugger command
+ * Execution exit to indicate that the debugging program has terminated due to a debugger
+ * command
  */
 class DebuggerExit final : public ExecExit {
 public:
-    explicit DebuggerExit(const std::string& message, const int code) : ExecExit(message, code) {}
+    explicit DebuggerExit(const std::string& message, const int32_t code) :
+        ExecExit(message, code) {}
 };
 
 
 /**
- * The possible exception codes thrown by the interpreter (stored in bits [2-6] of cause register)
+ * The possible exception codes thrown by the interpreter (stored in bits [2-6] of cause
+ * register)
  */
 enum class EXCEPT_CODE {
     ADDRESS_EXCEPTION_LOAD = 0x0010,

--- a/include/parser/instruction.h
+++ b/include/parser/instruction.h
@@ -163,8 +163,8 @@ enum class InstructionType {
     I_TYPE_T_L, // I-Type with 1 register and label
     I_TYPE_S_T_L, // I-Type with source registers swapped and label
     J_TYPE_L, // J-Type
-    SYSCALL, // Syscall
-    BREAK, // Syscall
+    SYSCALL, // Syscall instruction
+    BREAK, // Break instruction
 
     ERET, // Eret instruction
     CP0_TYPE_T_D, // Co-Processor 0 Type (Move from/to CP0)

--- a/include/parser/instruction.h
+++ b/include/parser/instruction.h
@@ -5,6 +5,7 @@
 #ifndef INSTRUCTION_H
 #define INSTRUCTION_H
 
+#include <climits>
 #include <cstdint>
 #include "tokenizer/tokenizer.h"
 
@@ -126,7 +127,7 @@ enum class InstructionCode {
     FP_MOV = 0x06,
 
     // Instruction Code for Pseudo Instructions
-    PSEUDO = 0x00,
+    PSEUDO = INT_MAX,
 };
 
 
@@ -202,10 +203,20 @@ struct InstructionOp {
 /**
  * Fetches the instruction associated with its name
  * @param name The name of the instruction
+ * @param args A list of arguments following the given instruction
  * @return The instruction representation
  * @throw runtime_error When an unknown instruction is named
  */
-InstructionOp nameToInstructionOp(const std::string& name);
+InstructionOp nameToInstructionOp(const std::string& name, const std::vector<Token>& args);
+
+
+/**
+ * Ensures that the given arguments an expected pattern of token types
+ * @param instructionType The type of instruction to match against
+ * @param args A list of arguments following the given instruction
+ * @throw runtime_error when the arguments for an instruction do not match its accepted values
+ */
+void validateInstructionArgs(InstructionType instructionType, const std::vector<Token>& args);
 
 
 /**

--- a/include/parser/instruction.h
+++ b/include/parser/instruction.h
@@ -83,6 +83,9 @@ enum class InstructionCode {
     // Syscall
     SYSCALL = 0x00,
 
+    // Break
+    BREAK = 0x00,
+
     // Co Processor 0 Instructions
     MFC0 = 0x00,
     MTC0 = 0x04,
@@ -161,6 +164,7 @@ enum class InstructionType {
     I_TYPE_S_T_L, // I-Type with source registers swapped and label
     J_TYPE_L, // J-Type
     SYSCALL, // Syscall
+    BREAK, // Syscall
 
     ERET, // Eret instruction
     CP0_TYPE_T_D, // Co-Processor 0 Type (Move from/to CP0)

--- a/include/parser/instruction.h
+++ b/include/parser/instruction.h
@@ -157,6 +157,7 @@ enum class InstructionType {
     R_TYPE_S, // R-Type with 1 source register
     I_TYPE_T_S_I, // I-Type
     I_TYPE_T_I, // I-Type with 1 register
+    I_TYPE_T_L, // I-Type with 1 register and label
     I_TYPE_S_T_L, // I-Type with source registers swapped and label
     J_TYPE_L, // J-Type
     SYSCALL, // Syscall

--- a/include/parser/labels.h
+++ b/include/parser/labels.h
@@ -28,7 +28,7 @@ public:
      * @param instructionArgs The instruction arguments to modify
      * @throw runtime_error When one of the arguments references an unknown label
      */
-    void resolveLabels(std::vector<Token>& instructionArgs);
+    void resolveLabels(std::vector<Token>& instructionArgs) const;
 
     /**
      * Looks up the first label corresponding to an address
@@ -51,6 +51,13 @@ public:
      * @return True if the label exists, false otherwise
      */
     bool contains(const std::string& label) const;
+
+    /**
+     * Fetches the address associated with a label
+     * @param label The label to fetch the address of
+     * @return The address associated with the label
+     */
+    uint32_t get(const std::string& label) const;
 
     [[nodiscard]] uint32_t operator[](const std::string& label) const { return labelMap.at(label); }
 

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -145,7 +145,7 @@ class Parser {
      * @param tokens The lines of tokens to resolve pseudo instructions for
      * @throw runtime_error When an unknown pseudo instruction is passed
      */
-    void resolvePseudoInstructions(std::vector<LineTokens>& tokens);
+    void resolvePseudoInstructions(std::vector<LineTokens>& tokens) const;
 
     /**
      * A helper method to parse the common formats of load/store pseudo instructions
@@ -154,7 +154,7 @@ class Parser {
      * @return The lines of tokens that represent the parsed load/store pseudo instruction
      */
     std::vector<std::vector<Token>>
-    parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args) const;
+    parseInstructionAliases(const Token& firstToken, const std::vector<Token>& args) const;
 
     /**
      * A helper method to parse the common formats of branch pseudo instructions

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -154,7 +154,7 @@ class Parser {
      * @return The lines of tokens that represent the parsed load/store pseudo instruction
      */
     std::vector<std::vector<Token>>
-    parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args);
+    parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args) const;
 
     /**
      * A helper method to parse the common formats of branch pseudo instructions
@@ -165,10 +165,10 @@ class Parser {
      * @param checkEq Whether the branch equal instruction is used for this branch type
      * @return The lines of tokens that represent the parsed branch pseudo instruction
      */
-    std::vector<std::vector<Token>> parseBranchPseudoInstruction(const Token& reg1,
-                                                                 const Token& reg2,
-                                                                 const Token& label, bool checkLt,
-                                                                 bool checkEq);
+    static std::vector<std::vector<Token>> parseBranchPseudoInstruction(const Token& reg1,
+                                                                        const Token& reg2,
+                                                                        const Token& label,
+                                                                        bool checkLt, bool checkEq);
 
     /**
      * Parse a single line of tokens into memory allocations

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -73,6 +73,13 @@ class Parser {
     std::vector<std::byte> parseSyscallInstruction() const;
 
     /**
+     * A specialized function to parse the break instruction
+     * @param code The break code associated with the instruction
+     * @return The memory allocation associated with the break instruction
+     */
+    std::vector<std::byte> parseBreakInstruction(uint32_t code) const;
+
+    /**
      * A specialized function to parse the eret instruction
      * @return The memory allocation associated with the eret instruction
      */
@@ -153,8 +160,8 @@ class Parser {
      * @param args The argument tokens for the pseudo instruction
      * @return The lines of tokens that represent the parsed load/store pseudo instruction
      */
-    std::vector<std::vector<Token>>
-    parseInstructionAliases(const Token& firstToken, const std::vector<Token>& args) const;
+    std::vector<std::vector<Token>> parseInstructionAliases(const Token& firstToken,
+                                                            const std::vector<Token>& args) const;
 
     /**
      * A helper method to parse the common formats of branch pseudo instructions

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -148,6 +148,15 @@ class Parser {
     void resolvePseudoInstructions(std::vector<LineTokens>& tokens);
 
     /**
+     * A helper method to parse the common formats of load/store pseudo instructions
+     * @param firstToken The token containing the load/store pseudo instruction
+     * @param args The argument tokens for the pseudo instruction
+     * @return The lines of tokens that represent the parsed load/store pseudo instruction
+     */
+    std::vector<std::vector<Token>>
+    parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args);
+
+    /**
      * A helper method to parse the common formats of branch pseudo instructions
      * @param reg1 The first register token
      * @param reg2 The second register token

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -39,9 +39,8 @@ int Interpreter::interpret(const MemLayout& layout) {
         try {
             step();
         } catch (ExecExit& e) {
-            std::ostringstream oss;
-            oss << "\n" << e.what() << std::endl;
-            streamHandle.putStr(oss.str());
+            streamHandle.putStr(e.what());
+            streamHandle.putStr("\n");
             return e.code();
         }
     }
@@ -177,6 +176,7 @@ void Interpreter::execInstruction(const int32_t instruction) {
     }
 
     const uint32_t opCode = instruction >> 26 & 0x3F;
+    const uint32_t funct = instruction & 0x3F; // Not always applicable to a single section
     if (opCode == 0x10) {
         // Co-Processor 0 instruction
         const uint32_t rs = instruction >> 21 & 0x1F;
@@ -222,9 +222,12 @@ void Interpreter::execInstruction(const int32_t instruction) {
 
         // Execute Co-Processor 1 immediate instruction
         execCP1ImmType(state.cp1, state.registers, state.memory, opCode, base, ft, offset);
+    } else if (opCode == 0x00 && funct == 0x0D) {
+        // Break instruction
+        const int32_t breakCode = instruction >> 6 & 0xFFFFF;
+        throw ExecExit("Break instruction executed", breakCode);
     } else if (opCode == 0x00) {
         // R-Type instruction
-        const uint32_t funct = instruction & 0x3F;
         const uint32_t rs = instruction >> 21 & 0x1F;
         const uint32_t rt = instruction >> 16 & 0x1F;
         const uint32_t rd = instruction >> 11 & 0x1F;

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -39,6 +39,7 @@ int Interpreter::interpret(const MemLayout& layout) {
         try {
             step();
         } catch (ExecExit& e) {
+            streamHandle.putStr("\n");
             streamHandle.putStr(e.what());
             streamHandle.putStr("\n");
             return e.code();

--- a/src/interpreter/syscalls.cpp
+++ b/src/interpreter/syscalls.cpp
@@ -197,7 +197,7 @@ void SystemHandle::heapAlloc(State& state) {
     state.registers[Register::V0] = ptr;
 }
 
-void SystemHandle::exit() { throw ExecExit("Program exited with code " + std::to_string(0), 0); }
+void SystemHandle::exit() { throw ExecExit("Program exited", 0); }
 
 void SystemHandle::printChar(const State& state, StreamHandle& streamHandle) {
     const char c = static_cast<char>(state.registers[Register::A0]);
@@ -211,7 +211,7 @@ void SystemHandle::readChar(State& state, StreamHandle& streamHandle) {
 
 void SystemHandle::exitVal(const State& state) {
     const int32_t exitCode = state.registers[Register::A0];
-    throw ExecExit("Program exited with code " + std::to_string(exitCode), exitCode);
+    throw ExecExit("Program exited", exitCode);
 }
 
 void SystemHandle::time(State& state) {

--- a/src/parser/instruction.cpp
+++ b/src/parser/instruction.cpp
@@ -152,71 +152,88 @@ std::map<std::string, InstructionOp> instructionNameMap = {
 };
 
 
+/**
+ * A mapping between instruction aliases and their associated properties
+ */
+const std::vector<std::pair<std::string, InstructionOp>> instructionAliasMap = {
+        {"lb", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"lbu", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"lh", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"lhu", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"lw", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+
+        {"sb", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"sh", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+        {"sw", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+};
+
+
 bool operator==(const uint32_t lhs, InstructionCode code) {
     return lhs == static_cast<uint32_t>(code);
 }
 
 
-InstructionOp nameToInstructionOp(const std::string& name) {
+InstructionOp nameToInstructionOp(const std::string& name, const std::vector<Token>& args) {
+    for (const auto& [aliasName, aliasOp] : instructionAliasMap) {
+        if (name != aliasName)
+            continue;
+        try {
+            validateInstructionArgs(aliasOp.type, args);
+            return aliasOp;
+        } catch (const std::runtime_error&) {
+        }
+    }
     if (instructionNameMap.contains(name))
         return instructionNameMap[name];
     throw std::runtime_error("Unknown instruction " + name);
 }
 
 
-void validateInstruction(const Token& instruction, const std::vector<Token>& args) {
-
-    switch (nameToInstructionOp(instruction.value).type) {
+void validateInstructionArgs(const InstructionType instructionType,
+                             const std::vector<Token>& args) {
+    switch (instructionType) {
         // Core CPU Instructions
         case InstructionType::R_TYPE_D_T_S:
         case InstructionType::R_TYPE_D_S_T:
             if (!tokenCategoryMatch(
                         {TokenCategory::REGISTER, TokenCategory::REGISTER, TokenCategory::REGISTER},
                         args))
-                throw std::runtime_error("Invalid format for R-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for R-Type instruction");
             break;
         case InstructionType::R_TYPE_D_T_H:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER,
                                      TokenCategory::IMMEDIATE},
                                     args))
-                throw std::runtime_error("Invalid format for R-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for R-Type instruction");
             break;
         case InstructionType::I_TYPE_S_T_L:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER,
                                      TokenCategory::LABEL_REF},
                                     args))
-                throw std::runtime_error("Invalid format for I-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for I-Type instruction");
             break;
         case InstructionType::I_TYPE_T_S_I:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER,
                                      TokenCategory::IMMEDIATE},
                                     args))
-                throw std::runtime_error("Invalid format for I-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for I-Type instruction");
             break;
         case InstructionType::I_TYPE_T_I:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::IMMEDIATE}, args))
-                throw std::runtime_error("Invalid format for I-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for I-Type instruction");
             break;
         case InstructionType::R_TYPE_S_T:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER}, args))
-                throw std::runtime_error("Invalid format for R-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for R-Type instruction");
             break;
         case InstructionType::R_TYPE_D:
         case InstructionType::R_TYPE_S:
             if (!tokenCategoryMatch({TokenCategory::REGISTER}, args))
-                throw std::runtime_error("Invalid format for R-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for R-Type instruction");
             break;
         case InstructionType::J_TYPE_L:
             if (!tokenCategoryMatch({TokenCategory::LABEL_REF}, args))
-                throw std::runtime_error("Invalid format for J-Type instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for J-Type instruction");
             break;
         case InstructionType::SYSCALL:
             if (!tokenCategoryMatch({}, args))
@@ -226,8 +243,7 @@ void validateInstruction(const Token& instruction, const std::vector<Token>& arg
         // Co-Processor 0 Instructions
         case InstructionType::CP0_TYPE_T_D:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER}, args))
-                throw std::runtime_error("Invalid format for Co-Processor 0 instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for Co-Processor 0 instruction");
             break;
         case InstructionType::ERET:
             if (!tokenCategoryMatch({}, args))
@@ -241,32 +257,39 @@ void validateInstruction(const Token& instruction, const std::vector<Token>& arg
         case InstructionType::CP1_TYPE_DP_S_T_C:
         case InstructionType::CP1_TYPE_T_S:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER}, args))
-                throw std::runtime_error("Invalid format for Co-Processor 1 instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for Co-Processor 1 instruction");
             break;
         case InstructionType::CP1_TYPE_SP_D_S_T:
         case InstructionType::CP1_TYPE_DP_D_S_T:
             if (!tokenCategoryMatch(
                         {TokenCategory::REGISTER, TokenCategory::REGISTER, TokenCategory::REGISTER},
                         args))
-                throw std::runtime_error("Invalid format for Co-Processor 1 instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for Co-Processor 1 instruction");
             break;
         case InstructionType::CP1_TYPE_T_S_I:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::REGISTER,
                                      TokenCategory::IMMEDIATE},
                                     args))
-                throw std::runtime_error("Invalid format for Co-Processor 1 instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for Co-Processor 1 instruction");
             break;
         case InstructionType::CP1_TYPE_L:
             if (!tokenCategoryMatch({TokenCategory::LABEL_REF}, args))
-                throw std::runtime_error("Invalid format for Co-Processor 1 instruction " +
-                                         instruction.value);
+                throw std::runtime_error("Invalid format for Co-Processor 1 instruction");
             break;
         default:
             // Should never be reached
-            throw std::runtime_error("Unknown instruction " + instruction.value);
+            throw std::runtime_error("Unknown instruction");
+    }
+}
+
+
+void validateInstruction(const Token& instruction, const std::vector<Token>& args) {
+    const InstructionType iType = nameToInstructionOp(instruction.value, args).type;
+    try {
+        validateInstructionArgs(iType, args);
+    } catch (const std::runtime_error& e) {
+        // Append instruction name to original error message
+        throw std::runtime_error(e.what() + std::string(" ") + instruction.value);
     }
 }
 

--- a/src/parser/instruction.cpp
+++ b/src/parser/instruction.cpp
@@ -175,6 +175,9 @@ const std::vector<std::pair<std::string, InstructionOp>> instructionAliasMap = {
         {"sb", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
         {"sh", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
         {"sw", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+
+        {"div", {InstructionType::R_TYPE_D_S_T, InstructionCode::PSEUDO, 8}},
+        {"divu", {InstructionType::R_TYPE_D_S_T, InstructionCode::PSEUDO, 8}},
 };
 
 

--- a/src/parser/instruction.cpp
+++ b/src/parser/instruction.cpp
@@ -165,6 +165,16 @@ const std::vector<std::pair<std::string, InstructionOp>> instructionAliasMap = {
         {"sb", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
         {"sh", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
         {"sw", {InstructionType::I_TYPE_T_I, InstructionCode::PSEUDO, 8}},
+
+        {"lb", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"lbu", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"lh", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"lhu", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"lw", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+
+        {"sb", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"sh", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
+        {"sw", {InstructionType::I_TYPE_T_L, InstructionCode::PSEUDO, 8}},
 };
 
 
@@ -220,6 +230,10 @@ void validateInstructionArgs(const InstructionType instructionType,
             break;
         case InstructionType::I_TYPE_T_I:
             if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::IMMEDIATE}, args))
+                throw std::runtime_error("Invalid format for I-Type instruction");
+            break;
+        case InstructionType::I_TYPE_T_L:
+            if (!tokenCategoryMatch({TokenCategory::REGISTER, TokenCategory::LABEL_REF}, args))
                 throw std::runtime_error("Invalid format for I-Type instruction");
             break;
         case InstructionType::R_TYPE_S_T:

--- a/src/parser/instruction.cpp
+++ b/src/parser/instruction.cpp
@@ -74,12 +74,12 @@ std::map<std::string, InstructionOp> instructionNameMap = {
         {"sw", {InstructionType::I_TYPE_T_S_I, InstructionCode::SW, 4}},
 
         // Remapped Instructions (supported by the ISA, but remapped for convenience of parsing)
-        {"beqz", {InstructionType::PSEUDO, InstructionCode::BEQZ, 4}},
-        {"bnez", {InstructionType::PSEUDO, InstructionCode::BNEZ, 4}},
-        {"bgtz", {InstructionType::PSEUDO, InstructionCode::BGTZ, 8}},
-        {"blez", {InstructionType::PSEUDO, InstructionCode::BLEZ, 8}},
-        {"bltz", {InstructionType::PSEUDO, InstructionCode::BLTZ, 8}},
-        {"bgez", {InstructionType::PSEUDO, InstructionCode::BGEZ, 8}},
+        {"beqz", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 4}},
+        {"bnez", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 4}},
+        {"bgtz", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 8}},
+        {"blez", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 8}},
+        {"bltz", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 8}},
+        {"bgez", {InstructionType::PSEUDO, InstructionCode::PSEUDO, 8}},
 
         // Syscall
         {"syscall", {InstructionType::SYSCALL, InstructionCode::SYSCALL, 4}},

--- a/src/parser/instruction.cpp
+++ b/src/parser/instruction.cpp
@@ -84,6 +84,9 @@ std::map<std::string, InstructionOp> instructionNameMap = {
         // Syscall
         {"syscall", {InstructionType::SYSCALL, InstructionCode::SYSCALL, 4}},
 
+        // Break
+        {"break", {InstructionType::BREAK, InstructionCode::BREAK, 4}},
+
         // Co-Processor 0 Instructions
         {"mfc0", {InstructionType::CP0_TYPE_T_D, InstructionCode::MFC0, 4}},
         {"mtc0", {InstructionType::CP0_TYPE_T_D, InstructionCode::MTC0, 4}},
@@ -255,6 +258,11 @@ void validateInstructionArgs(const InstructionType instructionType,
         case InstructionType::SYSCALL:
             if (!tokenCategoryMatch({}, args))
                 throw std::runtime_error("Invalid format for Syscall");
+            break;
+        case InstructionType::BREAK:
+            if (!tokenCategoryMatch({}, args) &&
+                !tokenCategoryMatch({TokenCategory::IMMEDIATE}, args))
+                throw std::runtime_error("Invalid format for Break");
             break;
 
         // Co-Processor 0 Instructions

--- a/src/parser/labels.cpp
+++ b/src/parser/labels.cpp
@@ -82,7 +82,7 @@ void LabelMap::populateLabelMap(const std::vector<LineTokens>& tokens) {
                         labelMap[label] = memSectionOffset(currSection) + memSizes[currSection];
                     pendingLabels.clear();
                     // Get size of instruction from map without parsing
-                    memSizes[currSection] += nameToInstructionOp(firstToken.value).size;
+                    memSizes[currSection] += nameToInstructionOp(firstToken.value, args).size;
                     break;
                 case TokenCategory::LABEL_DEF: {
                     if (labelMap.contains(firstToken.value) ||

--- a/src/parser/labels.cpp
+++ b/src/parser/labels.cpp
@@ -18,12 +18,17 @@
 bool LabelMap::contains(const std::string& label) const { return labelMap.contains(label); }
 
 
-void LabelMap::resolveLabels(std::vector<Token>& instructionArgs) {
+uint32_t LabelMap::get(const std::string& label) const {
+    if (!labelMap.contains(label))
+        throw std::runtime_error("Unknown label '" + unmangleLabel(label) + "'");
+    return labelMap.at(label);
+}
+
+
+void LabelMap::resolveLabels(std::vector<Token>& instructionArgs) const {
     for (Token& arg : instructionArgs)
         if (arg.category == TokenCategory::LABEL_REF) {
-            if (!labelMap.contains(arg.value))
-                throw std::runtime_error("Unknown label '" + unmangleLabel(arg.value) + "'");
-            arg = {TokenCategory::IMMEDIATE, std::to_string(labelMap[arg.value])};
+            arg = {TokenCategory::IMMEDIATE, std::to_string(get(arg.value))};
         }
 }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -216,6 +216,8 @@ std::vector<std::byte> Parser::parseInstruction(const uint32_t loc, const Token&
             return parseJTypeInstruction(opFuncCode, argCodes[0]);
         case InstructionType::SYSCALL:
             return parseSyscallInstruction();
+        case InstructionType::BREAK:
+            return parseBreakInstruction(argCodes.size() > 0 ? argCodes[0] : 0);
 
         // Co-Processor 0 Instructions
         case InstructionType::CP0_TYPE_T_D:
@@ -294,6 +296,13 @@ std::vector<std::byte> Parser::parseJTypeInstruction(const uint32_t opcode,
 
 std::vector<std::byte> Parser::parseSyscallInstruction() const {
     return useLittleEndian ? i32ToLEByte(0x0000000C) : i32ToBEByte(0x0000000C);
+}
+
+
+std::vector<std::byte> Parser::parseBreakInstruction(const uint32_t code) const {
+    // Combine fields into 32-bit instruction code
+    const uint32_t instruction = (0 & 0x3F) << 26 | (code & 0xFFFFF) << 6 | (0x0D & 0x3F);
+    return useLittleEndian ? i32ToLEByte(instruction) : i32ToBEByte(instruction);
 }
 
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -411,12 +411,9 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
             // la $tx, label -> lui $at, upperAddr; ori $tx, $at, lowerAddr
             else if (instructionName == "la") {
                 uint32_t value;
-                if (args[1].category == TokenCategory::LABEL_REF) {
-                    if (!labelMap.contains(args[1].value))
-                        throw std::runtime_error("Unknown label '" + unmangleLabel(args[1].value) +
-                                                 "'");
-                    value = labelMap[args[1].value];
-                } else
+                if (args[1].category == TokenCategory::LABEL_REF)
+                    value = labelMap.get(args[1].value);
+                else
                     value = stoui32(args[1].value);
 
                 const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
@@ -547,15 +544,14 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
 
 
 std::vector<std::vector<Token>>
-Parser::parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args) {
+Parser::parseLoadStorePseudoInstructions(const Token& firstToken,
+                                         const std::vector<Token>& args) const {
     std::vector<std::vector<Token>> parsedTokens = {{}, {}};
 
     uint32_t value;
-    if (args[1].category == TokenCategory::LABEL_REF) {
-        if (!labelMap.contains(args[1].value))
-            throw std::runtime_error("Unknown label '" + unmangleLabel(args[1].value) + "'");
-        value = labelMap[args[1].value];
-    } else
+    if (args[1].category == TokenCategory::LABEL_REF)
+        value = labelMap.get(args[1].value);
+    else
         value = stoui32(args[1].value);
 
     const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -156,7 +156,7 @@ std::vector<std::byte> Parser::parseInstruction(const uint32_t loc, const Token&
     // Resolve label references to their computed address values
     labelMap.resolveLabels(args);
 
-    InstructionOp instructionOp = nameToInstructionOp(instrToken.value);
+    InstructionOp instructionOp = nameToInstructionOp(instrToken.value, args);
     std::vector<uint32_t> argCodes = {};
     // Parse the instruction argument token values into integers
     for (const Token& arg : args) {
@@ -364,6 +364,29 @@ std::vector<std::byte> Parser::parseCP1CondImmInstruction(const uint32_t loc, co
 }
 
 
+std::vector<std::vector<Token>> parseLoadStorePseudoInstructions(const Token& firstToken,
+                                                                 const std::vector<Token>& args) {
+    std::vector<std::vector<Token>> parsedTokens = {{}, {}};
+
+    const uint32_t value = stoui32(args[1].value);
+    const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
+    const unsigned int lowerBytes = value & 0x0000FFFF;
+
+    parsedTokens[0] = {{TokenCategory::INSTRUCTION, "lui"},
+                       {TokenCategory::REGISTER, "at"},
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::IMMEDIATE, std::to_string(upperBytes)}};
+    parsedTokens[1] = {{TokenCategory::INSTRUCTION, firstToken.value},
+                       args[0],
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::REGISTER, "at"},
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::IMMEDIATE, std::to_string(lowerBytes)}};
+
+    return parsedTokens;
+}
+
+
 void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
     auto it = tokens.begin();
     while (it != tokens.end()) {
@@ -372,17 +395,33 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
         LineTokens originalTokenLine = tokenLine;
         try {
             const Token& firstToken = tokenLine.tokens[0];
+            const std::vector unfilteredArgs(tokenLine.tokens.begin() + 1, tokenLine.tokens.end());
+            std::vector<Token> args = filterTokenList(unfilteredArgs);
             if (firstToken.category != TokenCategory::INSTRUCTION ||
-                nameToInstructionOp(firstToken.value).type != InstructionType::PSEUDO) {
+                nameToInstructionOp(firstToken.value, args).opFuncCode != InstructionCode::PSEUDO) {
                 // If the first token is not an instruction, continue to the next line
                 ++it;
                 continue;
             }
-            const std::string instructionName = firstToken.value;
-            const std::vector unfilteredArgs(tokenLine.tokens.begin() + 1, tokenLine.tokens.end());
-            std::vector<Token> args = filterTokenList(unfilteredArgs);
 
             validatePseudoInstruction(firstToken, args);
+
+            const std::vector<std::string> loadStoreInstrs = {
+                    "lb", "lbu", "lh", "lhu", "lw", "sb", "sh", "sw",
+            };
+
+            const std::string instructionName = firstToken.value;
+            if (std::ranges::find(loadStoreInstrs, instructionName) != loadStoreInstrs.end()) {
+                std::vector<std::vector<Token>> parsedTokens =
+                        parseLoadStorePseudoInstructions(firstToken, args);
+                LineTokens line = originalTokenLine;
+                line.tokens = parsedTokens[0];
+                it = tokens.insert(it + 1, line);
+                line.tokens = parsedTokens[1];
+                it = tokens.insert(it + 1, line);
+                tokens.erase(it - 2); // Remove the pseudo instruction line
+                continue;
+            }
 
             // li $tx, imm -> addiu $tx, $zero, imm
             if (instructionName == "li") {
@@ -393,15 +432,7 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
             }
             // la $tx, label -> lui $at, upperAddr; ori $tx, $at, lowerAddr
             else if (instructionName == "la") {
-                uint32_t value;
-                if (args[1].category == TokenCategory::LABEL_REF) {
-                    if (!labelMap.contains(args[1].value))
-                        throw std::runtime_error("Unknown label '" + unmangleLabel(args[1].value) +
-                                                 "'");
-                    value = labelMap[args[1].value];
-                } else
-                    value = stoui32(args[1].value);
-
+                const uint32_t value = stoui32(args[1].value);
                 const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
                 const unsigned int lowerBytes = value & 0x0000FFFF;
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -32,7 +32,8 @@ MemLayout Parser::parse(const std::vector<LineTokens>& tokenLines, const bool ra
         modifiedTokenLines.insert(modifiedTokenLines.begin(), {"<unknown>", 0, nop});
     }
 
-    // Resolve all labels before parsing instructions
+    // Resolve all label locations before parsing instructions
+    // Label references still remain
     labelMap.populateLabelMap(modifiedTokenLines);
 
     // Insert jump to main instruction if the label is defined, otherwise start at first text word
@@ -432,7 +433,15 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
             }
             // la $tx, label -> lui $at, upperAddr; ori $tx, $at, lowerAddr
             else if (instructionName == "la") {
-                const uint32_t value = stoui32(args[1].value);
+                uint32_t value;
+                if (args[1].category == TokenCategory::LABEL_REF) {
+                    if (!labelMap.contains(args[1].value))
+                        throw std::runtime_error("Unknown label '" + unmangleLabel(args[1].value) +
+                                                 "'");
+                    value = labelMap[args[1].value];
+                } else
+                    value = stoui32(args[1].value);
+
                 const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
                 const unsigned int lowerBytes = value & 0x0000FFFF;
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -365,29 +365,6 @@ std::vector<std::byte> Parser::parseCP1CondImmInstruction(const uint32_t loc, co
 }
 
 
-std::vector<std::vector<Token>> parseLoadStorePseudoInstructions(const Token& firstToken,
-                                                                 const std::vector<Token>& args) {
-    std::vector<std::vector<Token>> parsedTokens = {{}, {}};
-
-    const uint32_t value = stoui32(args[1].value);
-    const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
-    const unsigned int lowerBytes = value & 0x0000FFFF;
-
-    parsedTokens[0] = {{TokenCategory::INSTRUCTION, "lui"},
-                       {TokenCategory::REGISTER, "at"},
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::IMMEDIATE, std::to_string(upperBytes)}};
-    parsedTokens[1] = {{TokenCategory::INSTRUCTION, firstToken.value},
-                       args[0],
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::REGISTER, "at"},
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::IMMEDIATE, std::to_string(lowerBytes)}};
-
-    return parsedTokens;
-}
-
-
 void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
     auto it = tokens.begin();
     while (it != tokens.end()) {
@@ -566,6 +543,36 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
             throw MasmSyntaxError(e.what(), originalTokenLine.filename, originalTokenLine.lineno);
         }
     }
+}
+
+
+std::vector<std::vector<Token>>
+Parser::parseLoadStorePseudoInstructions(const Token& firstToken, const std::vector<Token>& args) {
+    std::vector<std::vector<Token>> parsedTokens = {{}, {}};
+
+    uint32_t value;
+    if (args[1].category == TokenCategory::LABEL_REF) {
+        if (!labelMap.contains(args[1].value))
+            throw std::runtime_error("Unknown label '" + unmangleLabel(args[1].value) + "'");
+        value = labelMap[args[1].value];
+    } else
+        value = stoui32(args[1].value);
+
+    const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
+    const unsigned int lowerBytes = value & 0x0000FFFF;
+
+    parsedTokens[0] = {{TokenCategory::INSTRUCTION, "lui"},
+                       {TokenCategory::REGISTER, "at"},
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::IMMEDIATE, std::to_string(upperBytes)}};
+    parsedTokens[1] = {{TokenCategory::INSTRUCTION, firstToken.value},
+                       args[0],
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::REGISTER, "at"},
+                       {TokenCategory::SEPERATOR, ","},
+                       {TokenCategory::IMMEDIATE, std::to_string(lowerBytes)}};
+
+    return parsedTokens;
 }
 
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -217,7 +217,7 @@ std::vector<std::byte> Parser::parseInstruction(const uint32_t loc, const Token&
         case InstructionType::SYSCALL:
             return parseSyscallInstruction();
         case InstructionType::BREAK:
-            return parseBreakInstruction(argCodes.size() > 0 ? argCodes[0] : 0);
+            return parseBreakInstruction(!argCodes.empty() ? argCodes[0] : 0);
 
         // Co-Processor 0 Instructions
         case InstructionType::CP0_TYPE_T_D:
@@ -405,12 +405,14 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) const {
                 std::vector<std::vector<Token>> parsedTokens =
                         parseInstructionAliases(firstToken, args);
                 LineTokens line = originalTokenLine;
+                // Store the original position before insertions
+                auto erasePos = std::distance(tokens.begin(), it);
                 // Add new lines in the place of the original
                 for (const std::vector<Token>& parsedLine : parsedTokens) {
                     line.tokens = parsedLine;
                     it = tokens.insert(it + 1, line);
                 }
-                tokens.erase(it - parsedTokens.size()); // Remove the pseudo instruction line
+                tokens.erase(tokens.begin() + erasePos); // Remove the pseudo instruction
                 continue;
             }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -365,7 +365,7 @@ std::vector<std::byte> Parser::parseCP1CondImmInstruction(const uint32_t loc, co
 }
 
 
-void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
+void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) const {
     auto it = tokens.begin();
     while (it != tokens.end()) {
         LineTokens& tokenLine = *it;
@@ -373,31 +373,35 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
         LineTokens originalTokenLine = tokenLine;
         try {
             const Token& firstToken = tokenLine.tokens[0];
+            if (firstToken.category != TokenCategory::INSTRUCTION) {
+                // If the first token is not an instruction, continue to the next line
+                ++it;
+                continue;
+            }
+
             const std::vector unfilteredArgs(tokenLine.tokens.begin() + 1, tokenLine.tokens.end());
             std::vector<Token> args = filterTokenList(unfilteredArgs);
-            if (firstToken.category != TokenCategory::INSTRUCTION ||
-                nameToInstructionOp(firstToken.value, args).opFuncCode != InstructionCode::PSEUDO) {
-                // If the first token is not an instruction, continue to the next line
+            InstructionOp instructionOp = nameToInstructionOp(firstToken.value, args);
+            if (instructionOp.opFuncCode != InstructionCode::PSEUDO) {
+                // If the first token is not a pseudo instruction, continue to the next line
                 ++it;
                 continue;
             }
 
             validatePseudoInstruction(firstToken, args);
 
-            const std::vector<std::string> loadStoreInstrs = {
-                    "lb", "lbu", "lh", "lhu", "lw", "sb", "sh", "sw",
-            };
-
             const std::string instructionName = firstToken.value;
-            if (std::ranges::find(loadStoreInstrs, instructionName) != loadStoreInstrs.end()) {
+            // Handle instruction aliases
+            if (instructionOp.type != InstructionType::PSEUDO) {
                 std::vector<std::vector<Token>> parsedTokens =
-                        parseLoadStorePseudoInstructions(firstToken, args);
+                        parseInstructionAliases(firstToken, args);
                 LineTokens line = originalTokenLine;
-                line.tokens = parsedTokens[0];
-                it = tokens.insert(it + 1, line);
-                line.tokens = parsedTokens[1];
-                it = tokens.insert(it + 1, line);
-                tokens.erase(it - 2); // Remove the pseudo instruction line
+                // Add new lines in the place of the original
+                for (const std::vector<Token>& parsedLine : parsedTokens) {
+                    line.tokens = parsedLine;
+                    it = tokens.insert(it + 1, line);
+                }
+                tokens.erase(it - parsedTokens.size()); // Remove the pseudo instruction line
                 continue;
             }
 
@@ -544,29 +548,38 @@ void Parser::resolvePseudoInstructions(std::vector<LineTokens>& tokens) {
 
 
 std::vector<std::vector<Token>>
-Parser::parseLoadStorePseudoInstructions(const Token& firstToken,
-                                         const std::vector<Token>& args) const {
-    std::vector<std::vector<Token>> parsedTokens = {{}, {}};
+Parser::parseInstructionAliases(const Token& firstToken, const std::vector<Token>& args) const {
+    std::vector<std::vector<Token>> parsedTokens;
 
-    uint32_t value;
-    if (args[1].category == TokenCategory::LABEL_REF)
-        value = labelMap.get(args[1].value);
-    else
-        value = stoui32(args[1].value);
+    const std::vector<std::string> loadStoreInstrs = {
+            "lb", "lbu", "lh", "lhu", "lw", "sb", "sh", "sw",
+    };
+    if (std::ranges::find(loadStoreInstrs, firstToken.value) != loadStoreInstrs.end()) {
+        parsedTokens = {{}, {}};
+        uint32_t value;
+        if (args[1].category == TokenCategory::LABEL_REF)
+            value = labelMap.get(args[1].value);
+        else
+            value = stoui32(args[1].value);
 
-    const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
-    const unsigned int lowerBytes = value & 0x0000FFFF;
+        const unsigned int upperBytes = (value & 0xFFFF0000) >> 16;
+        const unsigned int lowerBytes = value & 0x0000FFFF;
 
-    parsedTokens[0] = {{TokenCategory::INSTRUCTION, "lui"},
-                       {TokenCategory::REGISTER, "at"},
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::IMMEDIATE, std::to_string(upperBytes)}};
-    parsedTokens[1] = {{TokenCategory::INSTRUCTION, firstToken.value},
-                       args[0],
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::REGISTER, "at"},
-                       {TokenCategory::SEPERATOR, ","},
-                       {TokenCategory::IMMEDIATE, std::to_string(lowerBytes)}};
+        parsedTokens[0] = {{TokenCategory::INSTRUCTION, "lui"},
+                           {TokenCategory::REGISTER, "at"},
+                           {TokenCategory::SEPERATOR, ","},
+                           {TokenCategory::IMMEDIATE, std::to_string(upperBytes)}};
+        parsedTokens[1] = {{TokenCategory::INSTRUCTION, firstToken.value},
+                           args[0],
+                           {TokenCategory::SEPERATOR, ","},
+                           {TokenCategory::REGISTER, "at"},
+                           {TokenCategory::SEPERATOR, ","},
+                           {TokenCategory::IMMEDIATE, std::to_string(lowerBytes)}};
+    } else if (firstToken.value == "div" || firstToken.value == "divu") {
+        parsedTokens = {{}, {}};
+        parsedTokens[0] = {firstToken, args[1], {TokenCategory::SEPERATOR, ","}, args[2]};
+        parsedTokens[1] = {{TokenCategory::INSTRUCTION, "mflo"}, args[0]};
+    }
 
     return parsedTokens;
 }

--- a/test/fixtures/arithmetic/arithmetic.txt
+++ b/test/fixtures/arithmetic/arithmetic.txt
@@ -1,2 +1,2 @@
 1024
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/echointer/echointer.txt
+++ b/test/fixtures/echointer/echointer.txt
@@ -1,2 +1,2 @@
 Hello there!q
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/globals/globalsOne.txt
+++ b/test/fixtures/globals/globalsOne.txt
@@ -1,3 +1,3 @@
 "Hello\World!"
 Hello, World again!
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/hello_world/hello_world.txt
+++ b/test/fixtures/hello_world/hello_world.txt
@@ -1,2 +1,2 @@
 Hello, World!
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/input_output/input_output.txt
+++ b/test/fixtures/input_output/input_output.txt
@@ -1,2 +1,2 @@
 Enter a number to calculate the factorial: The factorial is: 120
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/load_address/load_address.txt
+++ b/test/fixtures/load_address/load_address.txt
@@ -1,2 +1,2 @@
 l
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/loops/loops.txt
+++ b/test/fixtures/loops/loops.txt
@@ -1,2 +1,2 @@
 -1 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 /
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/mmio/mmio.txt
+++ b/test/fixtures/mmio/mmio.txt
@@ -1,2 +1,2 @@
 1234
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/mmio_le/mmio_le.txt
+++ b/test/fixtures/mmio_le/mmio_le.txt
@@ -1,2 +1,2 @@
 1234
-Program exited with code 0
+Program exited (code 0)

--- a/test/fixtures/syscall/syscall.txt
+++ b/test/fixtures/syscall/syscall.txt
@@ -1,3 +1,3 @@
 hello
 0.37454
-Program exited with code 0
+Program exited (code 0)

--- a/test/test_bindings.py
+++ b/test/test_bindings.py
@@ -91,7 +91,7 @@ class TestBindings:
 
                 interpreter.step()
             except pymasm.exceptions.ExecExit as e:
-                assert str(e) == "Program exited with code 0"
+                assert str(e) == "Program exited (code 0)"
                 break
 
         assert ostream.getvalue() == b'abcd'

--- a/test/test_components/test_syscall.cpp
+++ b/test/test_components/test_syscall.cpp
@@ -249,7 +249,7 @@ TEST_CASE("Test Heap Allocation Syscall") {
 TEST_CASE("Test Exit Syscall") {
     SystemHandle sysHandle;
     REQUIRE_THROWS_MATCHES(sysHandle.exit(), ExecExit,
-                           Catch::Matchers::Message("Program exited with code 0"));
+                           Catch::Matchers::Message("Program exited (code 0)"));
 }
 
 
@@ -285,7 +285,7 @@ TEST_CASE("Test Exit Value Syscall") {
     state.registers[Register::A0] = exitCode;
 
     REQUIRE_THROWS_MATCHES(sysHandle.exitVal(state), ExecExit,
-                           Catch::Matchers::Message("Program exited with code 42"));
+                           Catch::Matchers::Message("Program exited (code 42)"));
     try {
         sysHandle.exitVal(state);
     } catch (const ExecExit& e) {

--- a/test/test_instructions/test_aliased_instructions.cpp
+++ b/test/test_instructions/test_aliased_instructions.cpp
@@ -1,0 +1,60 @@
+//
+// Created by matthew on 5/23/25.
+//
+
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../testing_utilities.h"
+#include "interpreter/interpreter.h"
+#include "parser/parser.h"
+#include "tokenizer/tokenizer.h"
+
+
+// No execution tests are needed as the aliased instructions are made of other, tested instructions
+
+
+TEST_CASE("Test lw Instruction Alias") {
+    const SourceFile rawFile = makeRawFile({"lw $t0, 0xFFFF0000"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "lw"},
+                 {TokenCategory::REGISTER, "t0"},
+                 {TokenCategory::SEPERATOR, ","},
+                 {TokenCategory::IMMEDIATE, "4294901760"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x3c, 0x01, 0xff, 0xff, 0x8c, 0x28, 0x00, 0x00});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}
+
+
+TEST_CASE("Test sw Instruction Alias") {
+    const SourceFile rawFile = makeRawFile({"sw $t0, 0xFFFF0000"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "sw"},
+                 {TokenCategory::REGISTER, "t0"},
+                 {TokenCategory::SEPERATOR, ","},
+                 {TokenCategory::IMMEDIATE, "4294901760"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x3c, 0x01, 0xff, 0xff, 0xac, 0x28, 0x00, 0x00});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}

--- a/test/test_instructions/test_aliased_instructions.cpp
+++ b/test/test_instructions/test_aliased_instructions.cpp
@@ -15,7 +15,7 @@
 
 
 TEST_CASE("Test lw Instruction Alias") {
-    const SourceFile rawFile = makeRawFile({"lw $t0, 0xFFFF0000"});
+    const SourceFile rawFile = makeRawFile({"lw $t0, 0xffff0000"});
     const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
     SECTION("Test Tokenize") {
         const std::vector<std::vector<Token>> expectedTokens = {
@@ -37,8 +37,32 @@ TEST_CASE("Test lw Instruction Alias") {
 }
 
 
+TEST_CASE("Test lw Instruction Alias Labeled") {
+    const SourceFile rawFile = makeRawFile({"lw $t0, label"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "lw"},
+                 {TokenCategory::REGISTER, "t0"},
+                 {TokenCategory::SEPERATOR, ","},
+                 {TokenCategory::LABEL_REF, "label"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    parser.getLabels()["label"] = 0xffff0000;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x3c, 0x01, 0xff, 0xff, 0x8c, 0x28, 0x00, 0x00});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}
+
+
 TEST_CASE("Test sw Instruction Alias") {
-    const SourceFile rawFile = makeRawFile({"sw $t0, 0xFFFF0000"});
+    const SourceFile rawFile = makeRawFile({"sw $t0, 0xffff0000"});
     const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
     SECTION("Test Tokenize") {
         const std::vector<std::vector<Token>> expectedTokens = {
@@ -50,6 +74,30 @@ TEST_CASE("Test sw Instruction Alias") {
     }
 
     Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x3c, 0x01, 0xff, 0xff, 0xac, 0x28, 0x00, 0x00});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}
+
+
+TEST_CASE("Test sw Instruction Alias Labeled") {
+    const SourceFile rawFile = makeRawFile({"sw $t0, label"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "sw"},
+                 {TokenCategory::REGISTER, "t0"},
+                 {TokenCategory::SEPERATOR, ","},
+                 {TokenCategory::LABEL_REF, "label"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    parser.getLabels()["label"] = 0xffff0000;
     const MemLayout actualLayout = parser.parse(actualTokens, true);
     SECTION("Test Parse") {
         const std::vector<std::byte> expectedBytes =

--- a/test/test_instructions/test_aliased_instructions.cpp
+++ b/test/test_instructions/test_aliased_instructions.cpp
@@ -106,3 +106,55 @@ TEST_CASE("Test sw Instruction Alias Labeled") {
         REQUIRE(expectedBytes == actualBytes);
     }
 }
+
+
+TEST_CASE("Test div Instruction Three Registers") {
+    const SourceFile rawFile = makeRawFile({"div $t0, $t1, $t2"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {{
+                {TokenCategory::INSTRUCTION, "div"},
+                {TokenCategory::REGISTER, "t0"},
+                {TokenCategory::SEPERATOR, ","},
+                {TokenCategory::REGISTER, "t1"},
+                {TokenCategory::SEPERATOR, ","},
+                {TokenCategory::REGISTER, "t2"},
+        }};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x01, 0x2a, 0x00, 0x1a, 0x00, 0x00, 0x40, 0x12});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}
+
+
+TEST_CASE("Test divu Instruction Three Registers") {
+    const SourceFile rawFile = makeRawFile({"divu $t0, $t1, $t2"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {{
+                {TokenCategory::INSTRUCTION, "divu"},
+                {TokenCategory::REGISTER, "t0"},
+                {TokenCategory::SEPERATOR, ","},
+                {TokenCategory::REGISTER, "t1"},
+                {TokenCategory::SEPERATOR, ","},
+                {TokenCategory::REGISTER, "t2"},
+        }};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes =
+                iV2bV({0x01, 0x2a, 0x00, 0x1b, 0x00, 0x00, 0x40, 0x12});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+}

--- a/test/test_instructions/test_arithmetic_instructions.cpp
+++ b/test/test_instructions/test_arithmetic_instructions.cpp
@@ -4,11 +4,13 @@
 
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 #include "../testing_utilities.h"
 #include "debug/debug_interpreter.h"
+#include "exceptions.h"
 #include "interpreter/interpreter.h"
-#include "parser/instruction.h"
 #include "parser/parser.h"
 #include "tokenizer/tokenizer.h"
 
@@ -254,6 +256,15 @@ TEST_CASE("Test div Instruction") {
         REQUIRE(expectedLo == actualLo);
         REQUIRE(expectedHi == actualHi);
     }
+
+    interpreter.getState().registers[Register::T1] = 17;
+    interpreter.getState().registers[Register::T2] = 0;
+    SECTION("Test Execute Div Zero") {
+        REQUIRE_THROWS_MATCHES(
+                interpreter.interpret(actualLayout), MasmRuntimeError,
+                Catch::Matchers::Message("Runtime error at 0x00400000 (a.asm:1) -> Division by "
+                                         "zero: Division by zero in DIV instruction (unhandled)"));
+    }
 }
 
 
@@ -290,6 +301,15 @@ TEST_CASE("Test divu Instruction") {
         const int32_t actualHi = interpreter.getState().registers[Register::HI];
         REQUIRE(expectedLo == actualLo);
         REQUIRE(expectedHi == actualHi);
+    }
+
+    interpreter.getState().registers[Register::T1] = 17;
+    interpreter.getState().registers[Register::T2] = 0;
+    SECTION("Test Execute DivU Zero") {
+        REQUIRE_THROWS_MATCHES(
+                interpreter.interpret(actualLayout), MasmRuntimeError,
+                Catch::Matchers::Message("Runtime error at 0x00400000 (a.asm:1) -> Division by "
+                                         "zero: Division by zero in DIVU instruction (unhandled)"));
     }
 }
 

--- a/test/test_instructions/test_control_instructions.cpp
+++ b/test/test_instructions/test_control_instructions.cpp
@@ -4,9 +4,12 @@
 
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 #include "../testing_utilities.h"
 #include "debug/debug_interpreter.h"
+#include "exceptions.h"
 #include "interpreter/interpreter.h"
 #include "parser/parser.h"
 #include "tokenizer/tokenizer.h"
@@ -390,5 +393,96 @@ TEST_CASE("Test blez Instruction") {
     interpreterLt.interpret(actualLayout);
     SECTION("Test Execute Less Than") {
         REQUIRE(interpreterLt.getState().registers[Register::PC] == 0x00400010);
+    }
+}
+
+
+TEST_CASE("Test break Instruction") {
+    const SourceFile rawFile = makeRawFile({"break"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "break"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes = iV2bV({0x00, 0x00, 0x00, 0x0d});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+
+    std::ostringstream oss;
+    StreamHandle streamHandle(std::cin, oss);
+    DebugInterpreter interpreter(IOMode::SYSCALL, streamHandle);
+
+    SECTION("Test Execute") {
+        interpreter.interpret(actualLayout);
+        const std::string expectedOutput = "\nBreak instruction executed (code 0)";
+        REQUIRE(expectedOutput == oss.str());
+    }
+
+    std::string inputString = "c\nq\n";
+    std::istringstream iss(inputString);
+    oss.str("");
+    oss.clear();
+
+    StreamHandle interactiveStreamHandle(iss, oss);
+    DebugInterpreter interactiveInterpreter(IOMode::SYSCALL, interactiveStreamHandle);
+    interactiveInterpreter.setInteractive(true);
+    SECTION("Test Debugger") {
+        interactiveInterpreter.interpret(actualLayout);
+
+        const std::string expectedOutput = "\n(mdb) \nBreak instruction executed (code 0)\n"
+                                           "There is no program running.  Use 'run' to "
+                                           "restart\n\n(mdb) \nExiting debugger (code 0)";
+        REQUIRE(expectedOutput == oss.str());
+    }
+}
+
+
+TEST_CASE("Test break Instruction with Code") {
+    const SourceFile rawFile = makeRawFile({"break 42"});
+    const std::vector<LineTokens> actualTokens = Tokenizer::tokenizeFile({rawFile});
+    SECTION("Test Tokenize") {
+        const std::vector<std::vector<Token>> expectedTokens = {
+                {{TokenCategory::INSTRUCTION, "break"}, {TokenCategory::IMMEDIATE, "42"}}};
+        REQUIRE_NOTHROW(validateTokenLines(expectedTokens, actualTokens));
+    }
+
+    Parser parser;
+    const MemLayout actualLayout = parser.parse(actualTokens, true);
+    SECTION("Test Parse") {
+        const std::vector<std::byte> expectedBytes = iV2bV({0x00, 0x00, 0x0a, 0x8d});
+        const std::vector<std::byte> actualBytes = actualLayout.data.at(MemSection::TEXT);
+        REQUIRE(expectedBytes == actualBytes);
+    }
+
+    std::ostringstream oss;
+    StreamHandle streamHandle(std::cin, oss);
+    DebugInterpreter interpreter(IOMode::SYSCALL, streamHandle);
+
+    SECTION("Test Execute") {
+        interpreter.interpret(actualLayout);
+        const std::string expectedOutput = "\nBreak instruction executed (code 42)";
+        REQUIRE(expectedOutput == oss.str());
+    }
+
+    std::string inputString = "c\nq\n";
+    std::istringstream iss(inputString);
+    oss.str("");
+    oss.clear();
+
+    StreamHandle interactiveStreamHandle(iss, oss);
+    DebugInterpreter interactiveInterpreter(IOMode::SYSCALL, interactiveStreamHandle);
+    interactiveInterpreter.setInteractive(true);
+    SECTION("Test Debugger") {
+        interactiveInterpreter.interpret(actualLayout);
+        const std::string expectedOutput = "\n(mdb) \nBreak instruction executed (code 42)\n"
+                                           "There is no program running.  Use 'run' to "
+                                           "restart\n\n(mdb) \nExiting debugger (code 0)";
+        REQUIRE(expectedOutput == oss.str());
     }
 }


### PR DESCRIPTION
# Summary

This PR adds support for instruction aliases in addition to regular pseudo-instructions.  The distinction being that aliases are types of pseudo-instructions that share a mnemonic with real instructions.  This requires special handling.  Variants of the load and store operations along with three register variants of division have been added.

This PR also adds support for the `break` instruction and its variant that specifies an exit code.

## Related Issue(s)

* #17 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test or fixture update
