### PR TITLE
Add Info Memory Command to Debugger

### DIFF
--- a/libmasm/include/masm/simulator/cpu.hpp
+++ b/libmasm/include/masm/simulator/cpu.hpp
@@ -53,7 +53,7 @@ enum class Register {
      */
     K1,
     /**
-     * Stores a pointer to the global area of mmeory
+     * Stores a pointer to the global area of memory
      */
     GP,
     /**

--- a/libmasm/include/masm/simulator/heap.hpp
+++ b/libmasm/include/masm/simulator/heap.hpp
@@ -49,7 +49,7 @@ public:
     /**
      * Gets the total number of bytes allocated on the heap
      */
-    [[nodiscard]] size_t allocatedBytes() const;
+    [[nodiscard]] size_t allocated() const;
 
     /**
      * Gets the pointer to the top of heap memory

--- a/libmasm/include/masm/simulator/heap.hpp
+++ b/libmasm/include/masm/simulator/heap.hpp
@@ -24,6 +24,13 @@ class HeapAllocator {
     std::vector<uint32_t> blockSizes;
 
     /**
+     * A pointer to the current top of heap memory
+     *
+     * Initialized to 1MB
+     */
+    uint32_t heapPointer = memSectionOffset(MemSection::HEAP) + 0x100000;
+
+    /**
      * Finds the first unallocated space in the heap that can accommodate a block of the given size
      * @param size The size of the block to allocate
      * @return The first unallocated area that can fit the requested block
@@ -40,14 +47,14 @@ public:
     uint32_t allocate(uint32_t size);
 
     /**
-     * Gets the total number of bytes allocated
+     * Gets the total number of bytes allocated on the heap
      */
     [[nodiscard]] size_t allocatedBytes() const;
 
     /**
-     * Gets the maximum size of the heap
+     * Gets the pointer to the top of heap memory
      */
-    [[nodiscard]] static size_t heapSize();
+    [[nodiscard]] uint32_t top() const;
 };
 
 #endif // HEAP_H

--- a/libmasm/include/masm/simulator/heap.hpp
+++ b/libmasm/include/masm/simulator/heap.hpp
@@ -25,10 +25,8 @@ class HeapAllocator {
 
     /**
      * A pointer to the current top of heap memory
-     *
-     * Initialized to 1MB
      */
-    uint32_t heapPointer = memSectionOffset(MemSection::HEAP) + 0x100000;
+    uint32_t heapPointer = memSectionOffset(MemSection::HEAP);
 
     /**
      * Finds the first unallocated space in the heap that can accommodate a block of the given size

--- a/libmasm/include/masm/simulator/heap.hpp
+++ b/libmasm/include/masm/simulator/heap.hpp
@@ -38,6 +38,16 @@ public:
      * @throw runtime_error if the allocation fails
      */
     uint32_t allocate(uint32_t size);
+
+    /**
+     * Gets the total number of bytes allocated
+     */
+    [[nodiscard]] size_t allocatedBytes() const;
+
+    /**
+     * Gets the maximum size of the heap
+     */
+    [[nodiscard]] static size_t heapSize();
 };
 
 #endif // HEAP_H

--- a/libmasm/include/masm/simulator/heap.hpp
+++ b/libmasm/include/masm/simulator/heap.hpp
@@ -8,8 +8,6 @@
 
 #include <masm/assembler/memory.hpp>
 
-const uint32_t HEAP_BASE = memSectionOffset(MemSection::HEAP);
-constexpr uint32_t HEAP_SIZE = 0xfd00000; // 253 MiB
 
 /**
  * Class representing a simple heap allocator

--- a/libmasm/src/assembler/memory.cpp
+++ b/libmasm/src/assembler/memory.cpp
@@ -163,7 +163,7 @@ uint32_t memSectionOffset(const MemSection section) {
         case MemSection::HEAP:
             return 0x10040000; // Heap grows upwards, so this is the start of the heap
         case MemSection::GLOBAL:
-            return 0x10008000;
+            return 0x10000000;
         case MemSection::STACK:
             return 0x7fffeffc; // Stack grows downwards, so this is the top of the stack
         case MemSection::TEXT:

--- a/libmasm/src/simulator/heap.cpp
+++ b/libmasm/src/simulator/heap.cpp
@@ -9,12 +9,13 @@
 
 
 const uint32_t HEAP_BASE = memSectionOffset(MemSection::HEAP);
-constexpr uint32_t HEAP_SIZE = 0xfd00000; // 253 MiB
 
 
 uint32_t HeapAllocator::nextFree(const uint32_t size) const {
     uint32_t ptr = HEAP_BASE;
 
+    // Walk up through all allocated blocks to find a large enough free gap
+    // If no gap exists, the heap grows up towards the stack
     for (size_t i = 0; i < blockAddresses.size(); i++) {
         const uint32_t blkAddr = blockAddresses[i];
         const uint32_t blkSize = blockSizes[i];
@@ -36,8 +37,9 @@ uint32_t HeapAllocator::allocate(const uint32_t size) {
         throw ExecExcept("Cannot allocate zero bytes", EXCEPT_CODE::SYSCALL_EXCEPTION);
 
     const uint32_t address = nextFree(size);
-    if (address >= HEAP_BASE + HEAP_SIZE)
-        throw ExecExcept("Heap overflow", EXCEPT_CODE::SYSCALL_EXCEPTION);
+    // Grow heap pointer if more memory is needed
+    if (address + size > heapPointer)
+        heapPointer = address + size;
 
     // Insert new block sequentially before the block with the next greatest address
     for (size_t i = 0; i < blockAddresses.size(); i++) {
@@ -57,4 +59,4 @@ uint32_t HeapAllocator::allocate(const uint32_t size) {
 
 size_t HeapAllocator::allocatedBytes() const { return std::accumulate(blockSizes.begin(), blockSizes.end(), 0U); }
 
-size_t HeapAllocator::heapSize() { return HEAP_SIZE; }
+uint32_t HeapAllocator::top() const { return heapPointer; }

--- a/libmasm/src/simulator/heap.cpp
+++ b/libmasm/src/simulator/heap.cpp
@@ -7,6 +7,10 @@
 #include <masm/exceptions.hpp>
 
 
+const uint32_t HEAP_BASE = memSectionOffset(MemSection::HEAP);
+constexpr uint32_t HEAP_SIZE = 0xfd00000; // 253 MiB
+
+
 uint32_t HeapAllocator::nextFree(const uint32_t size) const {
     uint32_t ptr = HEAP_BASE;
 
@@ -37,8 +41,8 @@ uint32_t HeapAllocator::allocate(const uint32_t size) {
     // Insert new block sequentially before the block with the next greatest address
     for (size_t i = 0; i < blockAddresses.size(); i++) {
         if (blockAddresses[i] > address) {
-            blockAddresses.insert(blockAddresses.begin() + i, address);
-            blockSizes.insert(blockSizes.begin() + i, size);
+            blockAddresses.insert(blockAddresses.begin() + static_cast<int32_t>(i), address);
+            blockSizes.insert(blockSizes.begin() + static_cast<int32_t>(i), size);
             return address;
         }
     }

--- a/libmasm/src/simulator/heap.cpp
+++ b/libmasm/src/simulator/heap.cpp
@@ -57,6 +57,6 @@ uint32_t HeapAllocator::allocate(const uint32_t size) {
 }
 
 
-size_t HeapAllocator::allocatedBytes() const { return std::accumulate(blockSizes.begin(), blockSizes.end(), 0U); }
+size_t HeapAllocator::allocated() const { return std::accumulate(blockSizes.begin(), blockSizes.end(), 0U); }
 
 uint32_t HeapAllocator::top() const { return heapPointer; }

--- a/libmasm/src/simulator/heap.cpp
+++ b/libmasm/src/simulator/heap.cpp
@@ -5,6 +5,7 @@
 #include <masm/simulator/heap.hpp>
 
 #include <masm/exceptions.hpp>
+#include <numeric>
 
 
 const uint32_t HEAP_BASE = memSectionOffset(MemSection::HEAP);
@@ -52,3 +53,8 @@ uint32_t HeapAllocator::allocate(const uint32_t size) {
     blockSizes.push_back(size);
     return address;
 }
+
+
+size_t HeapAllocator::allocatedBytes() const { return std::accumulate(blockSizes.begin(), blockSizes.end(), 0U); }
+
+size_t HeapAllocator::heapSize() { return HEAP_SIZE; }

--- a/libmasm/src/simulator/simulator.cpp
+++ b/libmasm/src/simulator/simulator.cpp
@@ -18,8 +18,8 @@ void Simulator::initProgram(const MemLayout& layout) {
     // Initialize the stack registers
     state.registers[Register::FP] = static_cast<int32_t>(memSectionOffset(MemSection::STACK));
     state.registers[Register::SP] = static_cast<int32_t>(memSectionOffset(MemSection::STACK));
-    // Initialize the global pointer to the start of the global section
-    state.registers[Register::GP] = static_cast<int32_t>(memSectionOffset(MemSection::GLOBAL));
+    // Initialize the global pointer to the middle of the global section
+    state.registers[Register::GP] = static_cast<int32_t>(memSectionOffset(MemSection::GLOBAL)) + 0x00008000;
     // Set MMIO output ready bit to 1
     state.memory._sysWordTo(memSectionOffset(MemSection::MMIO) + 8, 1);
     // Enable interrupts

--- a/libmasm/src/simulator/syscalls.cpp
+++ b/libmasm/src/simulator/syscalls.cpp
@@ -193,6 +193,11 @@ void SystemHandle::readString(State& state, StreamHandle& streamHandle) {
 void SystemHandle::heapAlloc(State& state) {
     const int32_t size = state.registers[Register::A0];
     const int32_t ptr = static_cast<int32_t>(state.heapAllocator.allocate(size));
+
+    // Throw if the heap has overflowed past the stack
+    if (static_cast<int32_t>(state.heapAllocator.top()) > state.registers[Register::SP])
+        throw ExecExcept("Out of Memory", EXCEPT_CODE::SYSCALL_EXCEPTION);
+
     state.registers[Register::V0] = ptr;
 }
 

--- a/mdb/debug_simulator.cpp
+++ b/mdb/debug_simulator.cpp
@@ -551,10 +551,8 @@ void DebugSimulator::listMemorySegments() {
                                     state.registers[Register::GP]));
     streamHandle.putStr(std::format("data   0x{:08x}\n", memSectionOffset(MemSection::DATA)));
 
-    float heapPercentage = static_cast<float>(state.heapAllocator.allocatedBytes()) /
-                           static_cast<float>(HeapAllocator::heapSize()) * 100;
-    streamHandle.putStr(
-            std::format("heap   0x{:08x} ({:.2f}% used)\n", memSectionOffset(MemSection::HEAP), heapPercentage));
+    streamHandle.putStr(std::format("heap   0x{:08x} (ptr: 0x{:08x}, alloc: {}B)\n", memSectionOffset(MemSection::HEAP),
+                                    state.heapAllocator.top(), state.heapAllocator.allocated()));
     streamHandle.putStr(std::format("stack  0x{:08x} ($sp: 0x{:08x})\n", memSectionOffset(MemSection::STACK),
                                     state.registers[Register::SP]));
     streamHandle.putStr(std::format("ktext  0x{:08x}\n", memSectionOffset(MemSection::KTEXT)));

--- a/mdb/debug_simulator.cpp
+++ b/mdb/debug_simulator.cpp
@@ -547,14 +547,14 @@ void DebugSimulator::listLabels() {
 
 void DebugSimulator::listMemorySegments() {
     streamHandle.putStr(std::format("text   0x{:08x}\n", memSectionOffset(MemSection::TEXT)));
+    streamHandle.putStr(std::format("global 0x{:08x} ($gp: 0x{:08x})\n", memSectionOffset(MemSection::GLOBAL),
+                                    state.registers[Register::GP]));
     streamHandle.putStr(std::format("data   0x{:08x}\n", memSectionOffset(MemSection::DATA)));
 
     float heapPercentage = static_cast<float>(state.heapAllocator.allocatedBytes()) /
                            static_cast<float>(HeapAllocator::heapSize()) * 100;
     streamHandle.putStr(
             std::format("heap   0x{:08x} ({:.2f}% used)\n", memSectionOffset(MemSection::HEAP), heapPercentage));
-    streamHandle.putStr(std::format("global 0x{:08x} ($gp: 0x{:08x})\n", memSectionOffset(MemSection::GLOBAL),
-                                    state.registers[Register::GP]));
     streamHandle.putStr(std::format("stack  0x{:08x} ($sp: 0x{:08x})\n", memSectionOffset(MemSection::STACK),
                                     state.registers[Register::SP]));
     streamHandle.putStr(std::format("ktext  0x{:08x}\n", memSectionOffset(MemSection::KTEXT)));

--- a/mdb/debug_simulator.cpp
+++ b/mdb/debug_simulator.cpp
@@ -548,7 +548,11 @@ void DebugSimulator::listLabels() {
 void DebugSimulator::listMemorySegments() {
     streamHandle.putStr(std::format("text   0x{:08x}\n", memSectionOffset(MemSection::TEXT)));
     streamHandle.putStr(std::format("data   0x{:08x}\n", memSectionOffset(MemSection::DATA)));
-    streamHandle.putStr(std::format("heap   0x{:08x}\n", memSectionOffset(MemSection::HEAP)));
+
+    float heapPercentage = static_cast<float>(state.heapAllocator.allocatedBytes()) /
+                           static_cast<float>(HeapAllocator::heapSize()) * 100;
+    streamHandle.putStr(
+            std::format("heap   0x{:08x} ({:.2f}% used)\n", memSectionOffset(MemSection::HEAP), heapPercentage));
     streamHandle.putStr(std::format("global 0x{:08x} ($gp: 0x{:08x})\n", memSectionOffset(MemSection::GLOBAL),
                                     state.registers[Register::GP]));
     streamHandle.putStr(std::format("stack  0x{:08x} ($sp: 0x{:08x})\n", memSectionOffset(MemSection::STACK),

--- a/mdb/debug_simulator.cpp
+++ b/mdb/debug_simulator.cpp
@@ -31,6 +31,7 @@ const std::string debuggerHelp =
         "help, h - Show this help message\n"
         "info, i breakpoints - List all breakpoints\n"
         "info, i labels - List all labels\n"
+        "info, i memory - List the base addresses of program memory segments\n"
         "info, i registers - List all registers and their values\n"
         "info, i cp0 - List all Co-Processor 0 registers and their values\n"
         "info, i cp1 - List all Co-Processor 1 registers and their values\n"
@@ -324,6 +325,8 @@ bool DebugSimulator::execCommand(const std::string& cmdStr, const MemLayout& lay
                     listBreakpoints();
                 else if (args[0] == "labels")
                     listLabels();
+                else if (args[0] == "memory")
+                    listMemorySegments();
                 else if (args[0] == "registers")
                     listRegisters();
                 else if (args[0] == "cp0")
@@ -540,6 +543,19 @@ void DebugSimulator::listLabels() {
 
     if (!foundLabel)
         streamHandle.putStr("No labels found in the program");
+}
+
+void DebugSimulator::listMemorySegments() {
+    streamHandle.putStr(std::format("text   0x{:08x}\n", memSectionOffset(MemSection::TEXT)));
+    streamHandle.putStr(std::format("data   0x{:08x}\n", memSectionOffset(MemSection::DATA)));
+    streamHandle.putStr(std::format("heap   0x{:08x}\n", memSectionOffset(MemSection::HEAP)));
+    streamHandle.putStr(std::format("global 0x{:08x} ($gp: 0x{:08x})\n", memSectionOffset(MemSection::GLOBAL),
+                                    state.registers[Register::GP]));
+    streamHandle.putStr(std::format("stack  0x{:08x} ($sp: 0x{:08x})\n", memSectionOffset(MemSection::STACK),
+                                    state.registers[Register::SP]));
+    streamHandle.putStr(std::format("ktext  0x{:08x}\n", memSectionOffset(MemSection::KTEXT)));
+    streamHandle.putStr(std::format("kdata  0x{:08x}\n", memSectionOffset(MemSection::KDATA)));
+    streamHandle.putStr(std::format("MMIO   0x{:08x}\n", memSectionOffset(MemSection::MMIO)));
 }
 
 void DebugSimulator::listRegisters() {

--- a/mdb/debug_simulator.hpp
+++ b/mdb/debug_simulator.hpp
@@ -138,6 +138,11 @@ class DebugSimulator final : public Simulator {
     void listLabels();
 
     /**
+     * Lists the base addresses of program memory segments
+     */
+    void listMemorySegments();
+
+    /**
      * Lists all registers in the simulator, including general-purpose and special-purpose
      */
     void listRegisters();

--- a/tests/components/test_syscall.cpp
+++ b/tests/components/test_syscall.cpp
@@ -218,22 +218,23 @@ TEST_CASE("Test Read String Syscall") {
 TEST_CASE("Test Heap Allocation Syscall") {
     SystemHandle sysHandle;
     State state;
+    const uint32_t heapBaseAddr = memSectionOffset(MemSection::HEAP);
 
     SECTION("Test Heap Allocation with Valid Size") {
         state.registers[Register::A0] = 100;
         sysHandle.heapAlloc(state);
         uint32_t address = state.registers[Register::V0];
-        REQUIRE(address == HEAP_BASE);
+        REQUIRE(address == heapBaseAddr);
 
         state.registers[Register::A0] = 50;
         sysHandle.heapAlloc(state);
         address = state.registers[Register::V0];
-        REQUIRE(address == HEAP_BASE + 100);
+        REQUIRE(address == heapBaseAddr + 100);
 
         state.registers[Register::A0] = 200;
         sysHandle.heapAlloc(state);
         address = state.registers[Register::V0];
-        REQUIRE(address == HEAP_BASE + 150);
+        REQUIRE(address == heapBaseAddr + 150);
     }
 
     SECTION("Test Heap Allocation with Zero Size") {

--- a/tests/components/test_syscall.cpp
+++ b/tests/components/test_syscall.cpp
@@ -219,22 +219,29 @@ TEST_CASE("Test Heap Allocation Syscall") {
     SystemHandle sysHandle;
     State state;
     const uint32_t heapBaseAddr = memSectionOffset(MemSection::HEAP);
+    state.registers[Register::SP] = static_cast<int32_t>(memSectionOffset(MemSection::STACK));
 
     SECTION("Test Heap Allocation with Valid Size") {
         state.registers[Register::A0] = 100;
         sysHandle.heapAlloc(state);
         uint32_t address = state.registers[Register::V0];
         REQUIRE(address == heapBaseAddr);
+        REQUIRE(state.heapAllocator.allocated() == 100);
+        REQUIRE(state.heapAllocator.top() == heapBaseAddr + 100);
 
         state.registers[Register::A0] = 50;
         sysHandle.heapAlloc(state);
         address = state.registers[Register::V0];
         REQUIRE(address == heapBaseAddr + 100);
+        REQUIRE(state.heapAllocator.allocated() == 150);
+        REQUIRE(state.heapAllocator.top() == heapBaseAddr + 150);
 
         state.registers[Register::A0] = 200;
         sysHandle.heapAlloc(state);
         address = state.registers[Register::V0];
         REQUIRE(address == heapBaseAddr + 150);
+        REQUIRE(state.heapAllocator.allocated() == 350);
+        REQUIRE(state.heapAllocator.top() == heapBaseAddr + 350);
     }
 
     SECTION("Test Heap Allocation with Zero Size") {


### PR DESCRIPTION
# Summary

This PR adds an info command which displays the base addresses and relevant pointers for program memory sections.

## Related Issue(s)

* #32

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test or fixture update
* [ ] Reorganization or Refactor

